### PR TITLE
NewRelic integration.  The ENV vars referred to in the config file are already configured on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "turbolinks"
 gem "jbuilder", "~> 2.0"
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc
+gem "newrelic_rpm"
 
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     mini_portile2 (2.0.0)
     minitest (5.8.3)
     multi_json (1.11.2)
+    newrelic_rpm (3.14.1.311)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     parser (2.3.0.1)
@@ -180,6 +181,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  newrelic_rpm
   rails (~> 4.2)
   rspec-rails (~> 3.4)
   rubocop (~> 0.36)

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,28 @@
+common: &default_settings
+  license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
+  app_name: <%= "#{ENV['NEW_RELIC_APP_NAME']}-#{ENV['RAILS_ENV']}" %>
+  log_level: info
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+
+  # NOTE: There is substantial overhead when running in developer mode.
+  # Do not use for production or load testing.
+  developer_mode: true
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
In development, you don't need to set any API keys.  All your newrelic data is visible at http://localhost:3000/newrelic