### PR TITLE
Small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
   - STOCKAID_ENV_SETUP=2
   - STOCKAID_DATABASE_USERNAME=postgres
   - STOCKAID_DATABASE_PASSWORD=
-before_script:
-- psql -c 'create database stockaid_test;' -U postgres
 script:
+- bundle exec rake rubocop
+- psql -c 'create database stockaid_test;' -U postgres
 - RAILS_ENV=test bundle exec rake db:migrate --trace
-- bundle exec rake
+- bundle exec rake spec
 notifications:
   slack:
     secure: B456jmEXALlGTID/n8QQUWSKo5jerIRMrxq+zI+MpVh59IvVrQQcHQiTQx5nJhcI7urV8i+v42z2LRkVWpYDOPIpf1TZ5iV1wCct02rZ7STip5RCdhf6yiqRY8YwFMVKCpq4mHgb6VG9H2cciFbULtSAfBHAXODzZRCMkF+7sS/jyfw/lvbKSDArqWzA5obY9UVA8pN6AaCAXn84RU/DXykJYP9pa0qGhQftjaXRl4gLBWoMWwsu9Z7RyeCVAZYT24Rtn9BANaAZ3GHpjMryAayj/KMjYdrsdrzpczted259mSg6sYUy5xO9o/UcZW6aO/72kBcD6+IvWbWR5hFPktPope3cknuq7+9kcpgLL2I+UncZ1+c099OELOqhsSWkVROV4uO4pbIo94fnsTMGWWfPQagQb4X7cwj0v7jS3nUHRM2352iXEqAG7B4AjjTQGsuOWtGNWHC+atriaNIgsj0+floMCd7+/uDp1Ry0fRF1EJhbcNlH7seojWeFagE2Nub8jTc3EhlkWu8iHTNUmzuzrwhOA+dOH1GpzBGskliDB2tm1KPJOR1J7GtJzijDQtFIGy+5eNZoPV7YSNfiuSPHTzkbF63b7lQW7O4y41IdnqpAZEB1MO8IwXHnPWLz1q1+QKsxehdMvo1WGld2eboopU9YN82XzyGOmqMIQ5Q=

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
 
+  private_class_method def self.no_login(*options)
+    skip_before_action :authenticate_user!, *options
+  end
+
   private_class_method def self.active_tab(tab, *options)
     before_action(*options) { @active_tab = tab }
   end

--- a/app/controllers/user_invitations_controller.rb
+++ b/app/controllers/user_invitations_controller.rb
@@ -1,5 +1,5 @@
 class UserInvitationsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:show, :update]
+  no_login only: [:show, :update]
   require_permission :can_invite_user?, except: [:show, :update]
 
   def new

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -3,6 +3,7 @@ unless Rails.env.production?
   require "rspec/core/rake_task"
 
   RuboCop::RakeTask.new
-  task spec: [:check_setup, :rubocop]
-  task default: :spec
+  task spec: :check_setup
+  Rake::Task[:default].clear
+  task default: [:rubocop, :spec]
 end

--- a/spec/controllers/user_invitations_controller_spec.rb
+++ b/spec/controllers/user_invitations_controller_spec.rb
@@ -154,6 +154,7 @@ describe UserInvitationsController, type: :controller do
 
   describe "GET show" do
     it "fails with the wrong email" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
 
       expect do
@@ -165,6 +166,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "fails with the wrong auth code" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
 
       expect do
@@ -181,6 +183,7 @@ describe UserInvitationsController, type: :controller do
 
   describe "PUT update" do
     it "fails with the wrong email" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
 
       expect do
@@ -197,6 +200,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "fails with the wrong auth code" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
 
       expect do
@@ -213,6 +217,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "fails with an expired invitation" do
+      no_user_signed_in
       invite = user_invitations(:expired_acme_invite)
 
       expect do
@@ -229,6 +234,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "creates the user from the invite" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
 
       put :update,
@@ -251,6 +257,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "grants the user access to the desired organization" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
 
       put :update,
@@ -269,6 +276,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "grants the user admin access to the desired organization if the desired role was as an admin" do
+      no_user_signed_in
       invite = user_invitations(:acme_admin_invite)
 
       put :update,
@@ -287,6 +295,7 @@ describe UserInvitationsController, type: :controller do
     end
 
     it "invalidates all outstanding initations if successful" do
+      no_user_signed_in
       invite = user_invitations(:acme_invite)
       expect(UserInvitation.with_email(invite.email).not_expired.size > 1).to be_truthy
 

--- a/spec/support/controllers_helper.rb
+++ b/spec/support/controllers_helper.rb
@@ -1,4 +1,9 @@
 module ControllersHelper
+  def no_user_signed_in
+    stub_warden(nil)
+    stub_controller(nil)
+  end
+
   def signed_in_user(user_fixture)
     user = users(user_fixture)
     stub_warden(user)


### PR DESCRIPTION
Use no_login for clarity and so it could easily be extended
Specify in specs when no user should be signed in