### PR TITLE
Fix saving order changes

### DIFF
--- a/app/views/orders/edit.html.erb
+++ b/app/views/orders/edit.html.erb
@@ -31,7 +31,7 @@
         </table>
 
         <button class="btn btn-default add-item">Add Item</button>
-        <button type="submit" class="btn btn-primary add-item">Save Changes</button>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Remove the the add-item class from the Save Changes button to prevent
the click handler that shows the add_inventory_modal dialog from being
attached to the button. When the Save Changes button has the add-item
class, the click handler causes the Add Inventory Item dialog to pop
up when the button is pressed.