### PR TITLE
One more Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - 2.2
 services: postgresql
-bundler_args: "--without production --binstubs --jobs=3 --retry=3"
+bundler_args: "--without production development --binstubs --jobs=3 --retry=3"
 before_install: gem install bundler -v 1.11.2
 cache: bundler
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -21,14 +21,15 @@ gem "rack-timeout"
 gem "gratefulgarment-ui", git: "https://github.com/on-site/gratefulgarment-ui.git"
 
 group :development, :test do
-  # Call "byebug" anywhere in the code to stop execution and get a debugger console
-  gem "byebug"
-  gem "pry"
   gem "rspec-rails", "~> 3.4"
   gem "rubocop", "~> 0.36"
 end
 
 group :development do
+  # Call "byebug" anywhere in the code to stop execution and get a debugger console
+  gem "byebug"
+  gem "pry"
+
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem "web-console", "~> 2.0"
 


### PR DESCRIPTION
Drop gems in travis that aren't needed... they slow down build when gems get installed.