### PR TITLE
Fix selected attribute

### DIFF
--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -17,7 +17,7 @@
             <select name="status" class="form-control">
               <option value="">Show all statuses</option>
               <% Order::VALID_STATUSES.sort.each do |status| %>
-                <option value="<%= status %>"<%= "#{status.to_s == params[:status].to_s ? ' selected="selected"' : ''}" %>><%= status.to_s.titleize %></option>
+                <option value="<%= status %>" <%= "selected" if status.to_s == params[:status].to_s %>><%= status.to_s.titleize %></option>
               <% end %>
             </select>
           </div>


### PR DESCRIPTION
Ternary is unnecessary here as `nil` evaluates to empty string anyway.

The previous code is also incorrect as it does not use `.html_safe` on the ` selected="selected"` string.

Also, [per HTML 5 spec](https://www.w3.org/TR/html5/infrastructure.html#boolean-attributes), a boolean attribute can just be the attribute itself, and need not have a value, so it's a bit simpler to not need to use `.html_safe`.