### PR TITLE
New expose function for clearer intentions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,5 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require expose
 //= require_tree .
 //= require bootstrap-sprockets

--- a/app/assets/javascripts/expose.coffee
+++ b/app/assets/javascripts/expose.coffee
@@ -1,0 +1,8 @@
+# This function should be used instead of:
+#   window.something = -> ...
+# which can sometimes look like the "window." is an accident. Instead, use:
+#   expose "something", -> ...
+expose = (name, fn) ->
+  window[name] = fn
+
+expose "expose", expose

--- a/app/assets/javascripts/orders.coffee
+++ b/app/assets/javascripts/orders.coffee
@@ -17,7 +17,7 @@ showOrderDialog = (orderId) ->
     error: (jqXHR, textStatus, errorThrown) ->
       alert "Error occurred"
 
-window.orderRowClicked = (event, row, element) ->
+expose "orderRowClicked", (event, row, element) ->
   event.stopPropagation()
   orderId = row.data "order-id"
   showOrderDialog orderId


### PR DESCRIPTION
`window.` doesn't clearly reveal the intention, while `expose` hopefully is clearly *exosing* the function outside the current coffeescript file.