### PR TITLE
Use the item quantities to populate the quantity input field

### DIFF
--- a/app/assets/javascripts/orders.coffee
+++ b/app/assets/javascripts/orders.coffee
@@ -33,8 +33,13 @@ populateItems = (category_id, element) ->
       currentCategory = category
   element.empty()
   element.append """<option value="">Select an item...</option>"""
-  for {id, description} in currentCategory.items
-    element.append """<option value="#{id}">#{description}</option>"""
+  for {id, description, current_quantity, requested_quantity} in currentCategory.items
+    element.append """<option value="#{id}" data-current-quantity="#{current_quantity}" data-requested-quantity="#{requested_quantity}">#{description}</option>"""
+
+populateQuantity = (current_quantity, requested_quantity, element) ->
+  available_quantity = parseInt(current_quantity) - parseInt(requested_quantity)
+  element.val("")
+  element.attr("placeholder", available_quantity + " available")
 
 addNewOrderRow = ->
   currentNumRows = $("#new-order-table tbody").find("tr").length
@@ -51,9 +56,7 @@ addNewOrderRow = ->
         </select>
       </td>
       <td>
-        <select class="quantity form-control row-#{currentNumRows}">
-          <option value="">0</option>
-        </select>
+        <input class="quantity form-control row-#{currentNumRows}" placeholder="Select an Item..."/>
       </td>
     </tr>
   """)
@@ -73,6 +76,11 @@ $(document).on "click", "#add-item-row", (event) ->
 $(document).on "change", ".new-order-row .category", ->
   item_element = $(@).parents(".new-order-row").find ".item"
   populateItems $(@).val(), item_element
+
+$(document).on "change", ".new-order-row .item", ->
+  quantity_element = $(@).parents(".new-order-row").find ".quantity"
+  selected = $(@).find('option:selected')
+  populateQuantity selected.data("current-quantity"), selected.data("requested-quantity"), quantity_element
 
 $(document).on "page:change", ->
   addNewOrderRow() if $("#new-order-table").length > 0


### PR DESCRIPTION
Change the quantity dropdown to an input field and use the item's current and requested quantity amounts to add a placeholder that shows how many are available.

![screen shot 2016-03-01 at 11 00 56 am](https://cloud.githubusercontent.com/assets/1816102/13438221/f5afbb90-df9c-11e5-82d6-765efb23f2a1.png)

![screen shot 2016-03-01 at 11 01 08 am](https://cloud.githubusercontent.com/assets/1816102/13438220/f59fd0c2-df9c-11e5-9b2b-ad63848859a2.png)