### PR TITLE
Add rvm .ruby-env equivalent for rbenv (.rbenv-vars) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Ignore generated environment
 /.ruby-env
+/.rbenv-vars
 
 # Ignore the default SQLite database.
 /db/*.sqlite3


### PR DESCRIPTION
For those of us who prefer the rbenv way!