### PR TITLE
Don't expire all invites

### DIFF
--- a/spec/controllers/user_invitations_controller_spec.rb
+++ b/spec/controllers/user_invitations_controller_spec.rb
@@ -215,8 +215,22 @@ describe UserInvitationsController, type: :controller do
       end.to raise_error(PermissionError)
     end
 
-    # This shouldn't actually fail, but instead display an expired message
-    it "fails with an expired invitation"
+    describe "with an expired invitation" do
+      render_views
+
+      it "gives a failure message without the form" do
+        no_user_signed_in
+        invite = expired_acme_invite
+
+        get :show,
+            id: invite.id.to_s,
+            auth_token: invite.auth_token,
+            email: invite.email
+
+        expect(response.body).to include("invitation has expired")
+        expect(response.body).to_not include("<form")
+      end
+    end
   end
 
   describe "PUT update" do

--- a/spec/controllers/user_invitations_controller_spec.rb
+++ b/spec/controllers/user_invitations_controller_spec.rb
@@ -187,7 +187,24 @@ describe UserInvitationsController, type: :controller do
       expect(acme_normal.role_at(foo_inc)).to eq("none")
     end
 
-    it "sends an email notification when the user already exists"
+    it "sends an email notification when the user already exists" do
+      expect(acme_normal.role_at(foo_inc)).to be_nil
+      signed_in_user :foo_inc_root
+
+      expect do
+        post :create, user: {
+          organization_id: foo_inc.id.to_s,
+          name: "Foo Bar",
+          email: acme_normal.email,
+          role: "none"
+        }
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.to).to match_array(acme_normal.email)
+      expect(ActionMailer::Base.deliveries.last.body).to include(acme_normal.name)
+      expect(ActionMailer::Base.deliveries.last.body).to include(foo_inc_root.name)
+      expect(ActionMailer::Base.deliveries.last.body).to include(foo_inc.name)
+    end
   end
 
   describe "GET show" do

--- a/spec/controllers/user_invitations_controller_spec.rb
+++ b/spec/controllers/user_invitations_controller_spec.rb
@@ -7,6 +7,7 @@ describe UserInvitationsController, type: :controller do
   let(:root) { users(:root) }
   let(:acme_root) { users(:acme_root) }
   let(:acme_normal) { users(:acme_normal) }
+  let(:foo_inc_root) { users(:foo_inc_root) }
 
   let(:acme_invite) { user_invitations(:acme_invite) }
   let(:acme_admin_invite) { user_invitations(:acme_admin_invite) }
@@ -331,7 +332,7 @@ describe UserInvitationsController, type: :controller do
       expect(user.role_at(foo_inc)).to be_nil
     end
 
-    it "invalidates all outstanding initations if successful" do
+    it "invalidates all outstanding invitations to the same organization if successful" do
       no_user_signed_in
       invite = acme_invite
       expect(UserInvitation.with_email(invite.email).not_expired.size > 1).to be_truthy
@@ -347,6 +348,31 @@ describe UserInvitationsController, type: :controller do
           password_confirmation: "password123"
 
       expect(UserInvitation.with_email(invite.email).all?(&:expired?)).to be_truthy
+    end
+
+    it "automatically adds access to invitations from other organizations if successful" do
+      no_user_signed_in
+      invite = acme_invite
+      foo_inc_root.user_invitations.create! name: acme_invite.name,
+                                            email: acme_invite.email,
+                                            role: "admin",
+                                            organization: foo_inc
+
+      put :update,
+          id: invite.id.to_s,
+          auth_token: invite.auth_token,
+          email: invite.email,
+          name: "Acme Invited",
+          primary_number: "(408) 555-5123",
+          address: "1234 Main St, San Jose, CA 95123",
+          password: "password123",
+          password_confirmation: "password123"
+
+      expect(UserInvitation.with_email(invite.email).all?(&:expired?)).to be_truthy
+      user = User.find_by_email(invite.email)
+      expect(user.role_at(acme)).to eq("none")
+      expect(user.role_at(foo_inc)).to eq("admin")
+      expect(user.organization_users.size).to eq(2)
     end
   end
 end


### PR DESCRIPTION
This fixes #145 

This simply goes through and adds the new user to all organizations they are invited to, only doing so if they aren't yet a part of that organization. It grabs the first fetched, so if the user was invited to multiple roles at the same organization, this is not going to have predictable results, but I think it is a rare enough scenario that it doesn't matter (and it's easily correctable).