### PR TITLE
Drill down reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,7 +4,7 @@ class ReportsController < ApplicationController
   require_permission :can_view_reports?
 
   def value_by_county
-    @org_by_county = Organization.value_by_county_report
+    @report = Reports::ValueByCounty.new(params)
   end
 
   def total_inventory_value

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,7 +8,11 @@ class ReportsController < ApplicationController
   end
 
   def total_inventory_value
-    @category = Category.find(params[:category_id]) if params[:category_id]
-    @categories = Category.all
+    @categories =
+      if params[:category_id].present?
+        [Category.find(params[:category_id])]
+      else
+        Category.all
+      end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,11 +8,6 @@ class ReportsController < ApplicationController
   end
 
   def total_inventory_value
-    @categories =
-      if params[:category_id].present?
-        [Category.find(params[:category_id])]
-      else
-        Category.all
-      end
+    @report = Reports::TotalInventoryValue.new(params)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,6 +12,10 @@ class Category < ActiveRecord::Base
     }
   end
 
+  def value
+    items.sum("current_quantity * value")
+  end
+
   def self.to_json
     order(:description).inject_requested_quantities.map(&:to_json).to_json
   end
@@ -20,9 +24,5 @@ class Category < ActiveRecord::Base
     includes(:items).all.tap do |results|
       Item.inject_requested_quantities(results.map(&:items).flatten)
     end
-  end
-
-  def value
-    items.sum(:value)
   end
 end

--- a/app/models/concerns/order_status.rb
+++ b/app/models/concerns/order_status.rb
@@ -86,7 +86,12 @@ module OrderStatus
     send(status)
   end
 
+  APPROVED_STATUSES = %w(approved filled shipped received closed).map(&:freeze).freeze
   REQUESTED_STATUSES = %w(pending approved filled).map(&:freeze).freeze
+
+  def in_approved_status?
+    APPROVED_STATUSES.include?(status)
+  end
 
   def in_requested_status?
     REQUESTED_STATUSES.include?(status)
@@ -97,8 +102,16 @@ module OrderStatus
       where(status: status)
     end
 
+    def for_approved_statuses
+      for_status(approved_statuses)
+    end
+
     def for_requested_statuses
       for_status(requested_statuses)
+    end
+
+    def approved_statuses
+      @approved_statuses ||= APPROVED_STATUSES.map { |x| statuses[x] }.freeze
     end
 
     def requested_statuses

--- a/app/models/concerns/order_status.rb
+++ b/app/models/concerns/order_status.rb
@@ -75,7 +75,7 @@ module OrderStatus
       end
 
       event :close do
-        transition [:rejected, :received] => :closed
+        transition received: :closed
       end
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -35,6 +35,10 @@ class Item < ActiveRecord::Base
     references(requested_orders: :order_details).includes(requested_orders: :order_details)
   end
 
+  def total_value
+    current_quantity * value
+  end
+
   def requested_quantity
     @requested_quantity ||=
       begin

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -23,7 +23,7 @@ class Order < ActiveRecord::Base
   end
 
   def order_uneditable?
-    filled? || shipped? || received? || closed?
+    filled? || shipped? || received? || closed? || rejected?
   end
 
   def ship_to_addresses

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,22 +2,19 @@ class Organization < ActiveRecord::Base
   has_many :organization_users
   has_many :users, through: :organization_users
   has_many :orders
+  has_many :approved_orders, -> { for_approved_statuses.order(order_date: :desc) }, class_name: "Order"
   has_many :addresses
   accepts_nested_attributes_for :addresses, allow_destroy: true
   validates :name, uniqueness: true
 
   before_save :add_county
 
-  def reportable_orders
-    orders.where("status >= 1").order(order_date: :desc) # Approved
+  def approved_orders_value
+    @approved_orders_value ||= approved_orders.to_a.sum(&:value)
   end
 
-  def reportable_orders_value
-    reportable_orders.map(&:value).inject(0) { |a, e| a + e }
-  end
-
-  def reportable_orders_item_count
-    reportable_orders.map(&:item_count).inject(0) { |a, e| a + e }
+  def approved_orders_item_count
+    @approved_orders_item_count ||= approved_orders.to_a.sum(&:item_count)
   end
 
   def primary_address

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,28 +9,12 @@ class Organization < ActiveRecord::Base
 
   before_save :add_county
 
-  def approved_orders_value
-    @approved_orders_value ||= approved_orders.to_a.sum(&:value)
-  end
-
-  def approved_orders_item_count
-    @approved_orders_item_count ||= approved_orders.to_a.sum(&:item_count)
-  end
-
   def primary_address
     addresses.first
   end
 
-  def self.value_by_county_report
-    results = {}
-    counties.sort_by { |county| (county.presence || "no county").downcase }.each do |county_name|
-      results[county_name.presence || "No County"] = Organization.where(county: county_name)
-    end
-    results
-  end
-
   def self.counties
-    Organization.pluck(:county).uniq
+    pluck(:county).uniq
   end
 
   private

--- a/app/models/reports/total_inventory_value.rb
+++ b/app/models/reports/total_inventory_value.rb
@@ -1,0 +1,47 @@
+module Reports
+  module TotalInventoryValue
+    def self.new(params)
+      if params[:category_id].present?
+        Reports::TotalInventoryValue::SingleCategory.new(params)
+      else
+        Reports::TotalInventoryValue::AllCategories.new
+      end
+    end
+
+    class SingleCategory
+      attr_reader :category
+
+      def initialize(params)
+        @category = Category.find(params[:category_id])
+      end
+
+      def each
+        category.items.order(:description).each do |item|
+          yield item.description, item.total_value
+        end
+      end
+
+      def total_value
+        category.value
+      end
+    end
+
+    class AllCategories
+      attr_reader :categories
+
+      def initialize
+        @categories = Category.all
+      end
+
+      def each
+        categories.each do |category|
+          yield category.description, category.value
+        end
+      end
+
+      def total_value
+        categories.to_a.sum(&:value)
+      end
+    end
+  end
+end

--- a/app/models/reports/value_by_county.rb
+++ b/app/models/reports/value_by_county.rb
@@ -1,0 +1,88 @@
+module Reports
+  module ValueByCounty
+    NO_COUNTY = "No County".freeze
+
+    def self.new(params)
+      if params[:county].present?
+        Reports::ValueByCounty::SingleCounty.new(params)
+      else
+        Reports::ValueByCounty::AllCounties.new
+      end
+    end
+
+    def self.counties
+      Organization.counties.map { |x| x.presence || NO_COUNTY }.uniq.sort
+    end
+
+    module Base
+      def each
+        data.each { |x| yield(*x) }
+      end
+
+      def total_item_count
+        data.map { |x| x[1] }.sum
+      end
+
+      def total_value
+        data.map { |x| x[2] }.sum
+      end
+    end
+
+    class SingleCounty
+      include Reports::ValueByCounty::Base
+      attr_reader :county, :organizations
+
+      def initialize(params)
+        @county = params[:county]
+        @organizations = find_organizations.order(:name).includes(approved_orders: :order_details)
+      end
+
+      def description_label
+        "Organization"
+      end
+
+      private
+
+      def data
+        @data ||= organizations.map do |org|
+          orders = org.approved_orders.to_a
+          [org.name, orders.sum(&:item_count), orders.sum(&:value)]
+        end
+      end
+
+      def find_organizations
+        if county == NO_COUNTY
+          Organization.where("county IS NULL OR county = ''")
+        else
+          Organization.where(county: county)
+        end
+      end
+    end
+
+    class AllCounties
+      include Reports::ValueByCounty::Base
+      attr_reader :organizations
+
+      def initialize
+        @organizations = Organization.includes(approved_orders: :order_details).all
+                                     .group_by { |org| org.county.presence || NO_COUNTY }
+      end
+
+      def description_label
+        "County"
+      end
+
+      private
+
+      def data
+        @data ||= organizations.keys.sort.map do |county|
+          orgs = organizations[county]
+          orgs_orders = orgs.map { |org| org.approved_orders.to_a }
+          [county,
+           orgs_orders.sum { |orders| orders.sum(&:item_count) },
+           orgs_orders.sum { |orders| orders.sum(&:value) }]
+        end
+      end
+    end
+  end
+end

--- a/app/views/orders/_status_buttons.html.erb
+++ b/app/views/orders/_status_buttons.html.erb
@@ -52,10 +52,6 @@
     <i class="glyphicon glyphicon-chevron-left"></i>
     Back to Pending
   </button>
-  <button type="submit" name="order[status]" value="close" class="btn btn-primary">
-    Close Order
-    <i class="glyphicon glyphicon-chevron-right"></i>
-  </button>
 <% elsif order.filled? %>
   <button type="submit" name="order[status]" value="ship" class="btn btn-primary">
     Ship

--- a/app/views/reports/_category_value.html.erb
+++ b/app/views/reports/_category_value.html.erb
@@ -1,4 +1,0 @@
-<tr>
-  <td class="col-xs-4"><%= category.description %></td>
-  <td class="text-center"><%= number_to_currency(category.value, precision: 2) %></td>
-</tr>

--- a/app/views/reports/total_inventory_value.html.erb
+++ b/app/views/reports/total_inventory_value.html.erb
@@ -4,9 +4,9 @@
 
 <% content_for :sidebar do %>
   <ul id="category_nav" class="nav nav-pills nav-stacked">
-    <%= tab("All Categories", total_inventory_value_reports_path, @category == nil) %>
-    <% @categories.all.each do |category| %>
-      <%= tab(category.description, total_inventory_value_reports_path(report: :total_inventory_value, category_id: category.id), @category == category) %>
+    <%= tab("All Categories", total_inventory_value_reports_path, params[:category_id].blank?) %>
+    <% Category.all.each do |category| %>
+      <%= tab(category.description, total_inventory_value_reports_path(category_id: category.id), params[:category_id].present? && category.id == params[:category_id].to_i) %>
     <% end %>
   </ul>
 <% end %>
@@ -22,14 +22,20 @@
       </thead>
 
       <tbody>
-        <% if @category.present? %>
-          <%= render partial: "category_value", locals: { category: @category } %>
-        <% else %>
-          <% @categories.each do |category| %>
-            <%= render partial: "category_value", locals: { category: category } %>
-          <% end %>
+        <% @categories.each do |category| %>
+          <tr>
+            <td class="col-xs-4"><%= category.description %></td>
+            <td class="text-center"><%= number_to_currency(category.value, precision: 2) %></td>
+          </tr>
         <% end %>
       </tbody>
+
+      <tfoot>
+        <tr>
+          <th class="col-xs-4">Total</th>
+          <th class="text-center"><%= number_to_currency(@categories.to_a.sum(&:value), precision: 2) %></th>
+        </tr>
+      </tfoot>
     </table>
   </div>
 <% end %>

--- a/app/views/reports/total_inventory_value.html.erb
+++ b/app/views/reports/total_inventory_value.html.erb
@@ -3,7 +3,7 @@
 <% content_for :content_size, "col-sm-9 col-md-10" %>
 
 <% content_for :sidebar do %>
-  <ul id="category_nav" class="nav nav-pills nav-stacked">
+  <ul class="nav nav-pills nav-stacked">
     <%= tab("All Categories", total_inventory_value_reports_path, params[:category_id].blank?) %>
     <% Category.all.each do |category| %>
       <%= tab(category.description, total_inventory_value_reports_path(category_id: category.id), params[:category_id].present? && category.id == params[:category_id].to_i) %>
@@ -22,10 +22,10 @@
       </thead>
 
       <tbody>
-        <% @categories.each do |category| %>
+        <% @report.each do |description, value| %>
           <tr>
-            <td class="col-xs-4"><%= category.description %></td>
-            <td class="text-center"><%= number_to_currency(category.value, precision: 2) %></td>
+            <td class="col-xs-4"><%= description %></td>
+            <td class="text-center"><%= number_to_currency(value, precision: 2) %></td>
           </tr>
         <% end %>
       </tbody>
@@ -33,7 +33,7 @@
       <tfoot>
         <tr>
           <th class="col-xs-4">Total</th>
-          <th class="text-center"><%= number_to_currency(@categories.to_a.sum(&:value), precision: 2) %></th>
+          <th class="text-center"><%= number_to_currency(@report.total_value, precision: 2) %></th>
         </tr>
       </tfoot>
     </table>

--- a/app/views/reports/value_by_county.html.erb
+++ b/app/views/reports/value_by_county.html.erb
@@ -3,47 +3,42 @@
 <% content_for :content_size, "col-sm-9 col-md-10" %>
 
 <% content_for :sidebar do %>
-  <ul id="county_nav" class="nav nav-pills nav-stacked" role="tablist">
-    <% @org_by_county.each_with_index do |(county_name, organizations), index| %>
-      <li role="presentation" class="<%= 'active' if index == 0 %>">
-        <a href="#county-<%= index %>" aria-controls="<%= index %>" role="tab" data-toggle="pill"><%= county_name %></a>
-      </li>
+  <ul class="nav nav-pills nav-stacked" role="tablist">
+    <%= tab("All Counties", value_by_county_reports_path, params[:county].blank?) %>
+    <% Reports::ValueByCounty.counties.each do |county| %>
+      <%= tab(county, value_by_county_reports_path(county: county), county == params[:county]) %>
     <% end %>
   </ul>
 <% end %>
 
 <% content_for :content do %>
   <div class="tab-content">
-    <% @org_by_county.each_with_index do |(county_name, organizations), index| %>
-      <div role="tabpanel" class="tab-pane <%= 'active' if index == 0 %>" id="county-<%= index %>">
-        <table class="table table-striped table-responsive data-table sort-asc">
-          <thead>
-            <tr>
-              <th>Organization</th>
-              <th class="text-center">Number of Items</th>
-              <th class="text-center">Value of Orders</th>
-            </tr>
-          </thead>
+    <table class="table table-striped table-responsive data-table sort-asc">
+      <thead>
+        <tr>
+          <th><%= @report.description_label %></th>
+          <th class="text-center">Number of Items</th>
+          <th class="text-center">Value of Orders</th>
+        </tr>
+      </thead>
 
-          <tbody>
-            <% organizations.each do |org| %>
-              <tr>
-                <td><%= org.name %></td>
-                <td class="text-center"><%= org.approved_orders_item_count %></td>
-                <td class="text-center"><%= number_to_currency org.approved_orders_value, precision: 2 %></td>
-              </tr>
-            <% end %>
-          </tbody>
+      <tbody>
+        <% @report.each do |description, item_count, value| %>
+          <tr>
+            <td><%= description %></td>
+            <td class="text-center"><%= item_count %></td>
+            <td class="text-center"><%= number_to_currency value, precision: 2 %></td>
+          </tr>
+        <% end %>
+      </tbody>
 
-          <tfoot>
-            <tr>
-              <th>Total</th>
-              <th class="text-center"><%= organizations.to_a.sum(&:approved_orders_item_count) %></th>
-              <th class="text-center"><%= number_to_currency organizations.to_a.sum(&:approved_orders_value), precision: 2 %></th>
-            </tr>
-          </tfoot>
-        </table>
-      </div>
-    <% end %>
+      <tfoot>
+        <tr>
+          <th>Total</th>
+          <th class="text-center"><%= @report.total_item_count %></th>
+          <th class="text-center"><%= number_to_currency @report.total_value, precision: 2 %></th>
+        </tr>
+      </tfoot>
+    </table>
   </div>
 <% end %>

--- a/app/views/reports/value_by_county.html.erb
+++ b/app/views/reports/value_by_county.html.erb
@@ -19,7 +19,7 @@
         <table class="table table-striped table-responsive data-table sort-asc">
           <thead>
             <tr>
-              <th class="">Organization</th>
+              <th>Organization</th>
               <th class="text-center">Number of Items</th>
               <th class="text-center">Value of Orders</th>
             </tr>
@@ -29,11 +29,19 @@
             <% organizations.each do |org| %>
               <tr>
                 <td><%= org.name %></td>
-                <td class="text-center"><%= org.reportable_orders_item_count %></td>
-                <td class="text-center">$<%= org.reportable_orders_value %></td>
+                <td class="text-center"><%= org.approved_orders_item_count %></td>
+                <td class="text-center"><%= number_to_currency org.approved_orders_value, precision: 2 %></td>
               </tr>
             <% end %>
           </tbody>
+
+          <tfoot>
+            <tr>
+              <th>Total</th>
+              <th class="text-center"><%= organizations.to_a.sum(&:approved_orders_item_count) %></th>
+              <th class="text-center"><%= number_to_currency organizations.to_a.sum(&:approved_orders_value), precision: 2 %></th>
+            </tr>
+          </tfoot>
         </table>
       </div>
     <% end %>


### PR DESCRIPTION
This PR includes #411 

On top of the fixes and refactorings from #411, this PR moves report data into their own classes and abstracts the interface so it can differ depending on the parameters to the report.

I also added drill downs for the reports... so in the inventory value report, selecting a category will show that category's items and corresponding total value, rather than just that single row. In the value by county report, you can now see all county values at a glance, or drill into a particular county to see the actual organizations of that county, and the corresponding data.