### PR TITLE
417 ship to name defaults

### DIFF
--- a/app/models/concerns/users/order_manipulator.rb
+++ b/app/models/concerns/users/order_manipulator.rb
@@ -40,5 +40,13 @@ module Users
         order
       end
     end
+
+    def ship_to_names(order)
+      if super_admin? || order.user.super_admin?
+        order.organization_ship_to_names
+      else
+        order.ship_to_names
+      end
+    end
   end
 end

--- a/app/models/concerns/users/order_manipulator.rb
+++ b/app/models/concerns/users/order_manipulator.rb
@@ -21,8 +21,8 @@ module Users
         order = Order.new(organization: organization,
                           user: self,
                           order_date: Time.zone.now,
-                          status: :select_ship_to,
-                          ship_to_name: name)
+                          status: :select_ship_to)
+        order.ship_to_name = name unless super_admin?
         OrderDetailsUpdater.new(order, params).update
         order.save!
         order

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,6 +34,12 @@ class Order < ActiveRecord::Base
     [user.name.to_s, "#{organization.name} c/o #{user.name}"]
   end
 
+  def organization_ship_to_names
+    organization.users.map do |user|
+      [user.name.to_s, "#{organization.name} c/o #{user.name}"]
+    end.flatten
+  end
+
   def to_json
     {
       id: id,

--- a/app/views/orders/status/select_ship_to.html.erb
+++ b/app/views/orders/status/select_ship_to.html.erb
@@ -14,7 +14,7 @@
 
       <div class="col-xs-7">
         <div class="btn-group">
-          <% @order.ship_to_names.each do |name| %>
+          <% current_user.ship_to_names(@order).each do |name| %>
             <%= button_tag name, type: "button", class: "btn btn-default suggested-name" %>
           <% end %>
         </div>


### PR DESCRIPTION
This fixes #417 
Don't default to current user for `ship_to_name` when the current user is a super admin. Instead, leave it blank, forcing a reasonable selection when selecting the shipping address.

Allow super admins to select any `ship_to_name` from the organization. Also allow the same when a super admin had created the order.