### PR TITLE
419 Fix order errors

### DIFF
--- a/app/models/concerns/order_status.rb
+++ b/app/models/concerns/order_status.rb
@@ -1,4 +1,4 @@
-module OrderStatus
+module OrderStatus # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
   included do
     # Order processing flowchart

--- a/app/models/concerns/order_status.rb
+++ b/app/models/concerns/order_status.rb
@@ -31,6 +31,12 @@ module OrderStatus
 
       event :confirm_ship_to do
         transition select_ship_to: :confirm_order
+
+        after do
+          order_details.each do |od|
+            od.destroy! if od.quantity == 0
+          end
+        end
       end
 
       event :submit_order do

--- a/app/models/concerns/users/order_manipulator.rb
+++ b/app/models/concerns/users/order_manipulator.rb
@@ -29,13 +29,10 @@ module Users
       end
     end
 
-    def update_order(params) # rubocop:disable Metrics/AbcSize
+    def update_order(params)
       transaction do
         order = Order.find params[:id]
-        OrderDetailsUpdater.new(order, params).update
-        order.add_shipments(params) if params[:order][:shipments].present?
-        order.ship_to_address = params[:order][:ship_to_address] if params[:order][:ship_to_address].present?
-        order.update_status(params[:order][:status])
+        OrderUpdater.new(order, params).update
         order.save!
         order
       end

--- a/app/models/order_details_updater.rb
+++ b/app/models/order_details_updater.rb
@@ -12,8 +12,6 @@ class OrderDetailsUpdater
       zero_out
       add_new_details
     end
-
-    delete_zeros if order_status == "confirm_ship_to"
   end
 
   private
@@ -75,12 +73,6 @@ class OrderDetailsUpdater
   def zero_out
     item_ids_to_zero.each do |item_id|
       order_details_hash[item_id].quantity = 0
-    end
-  end
-
-  def delete_zeros
-    order_details.each do |od|
-      od.destroy if od.quantity == 0
     end
   end
 

--- a/app/models/order_details_updater.rb
+++ b/app/models/order_details_updater.rb
@@ -7,11 +7,10 @@ class OrderDetailsUpdater
   end
 
   def update
-    if new_order_details_present?
-      update_exsisting
-      zero_out
-      add_new_details
-    end
+    return unless new_order_details_present?
+    update_exsisting
+    zero_out
+    add_new_details
   end
 
   private

--- a/app/models/order_details_updater.rb
+++ b/app/models/order_details_updater.rb
@@ -7,19 +7,27 @@ class OrderDetailsUpdater
   end
 
   def update
-    if new_order_details.present?
+    if new_order_details_present?
       update_exsisting
       zero_out
       add_new_details
     end
 
-    delete_zeros if params[:order][:status] == "confirm_ship_to"
+    delete_zeros if order_status == "confirm_ship_to"
   end
 
   private
 
-  def new_order_details
-    params[:order][:order_details]
+  def order_status
+    if params[:order].present? && params[:order][:status].present?
+      params[:order][:status]
+    else
+      "unknown"
+    end
+  end
+
+  def new_order_details_present?
+    params[:order].present? && params[:order][:order_details].present?
   end
 
   def new_item_ids

--- a/app/models/order_updater.rb
+++ b/app/models/order_updater.rb
@@ -1,0 +1,36 @@
+class OrderUpdater
+  attr_reader :order, :params
+
+  def initialize(order, params)
+    @order = order
+    @params = params
+  end
+
+  def update
+    update_details
+    update_shipments
+    update_address
+    update_status
+  end
+
+  private
+
+  def update_details
+    OrderDetailsUpdater.new(order, params).update
+  end
+
+  def update_shipments
+    return unless params[:order].present? && params[:order][:shipments].present?
+    order.add_shipments(params)
+  end
+
+  def update_address
+    return unless params[:order].present? && params[:order][:ship_to_address].present?
+    order.ship_to_address = params[:order][:ship_to_address]
+  end
+
+  def update_status
+    return unless params[:order].present? && params[:order][:status].present?
+    order.update_status(params[:order][:status])
+  end
+end


### PR DESCRIPTION
This fixes #419 

Protect accesses like `params[:order][:something]` to check that `params[:order]` exists first.

I did some refactoring along with the fix.