### PR TITLE
Add a down for maintenance page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,11 @@ group :development, :test do
   gem "rubocop", "~> 0.36"
 end
 
+group :test do
+  gem "climate_control", "~> 0.2"
+  gem "fakefs", "~> 0.11", require: "fakefs/safe"
+end
+
 group :development do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     builder (3.2.2)
     byebug (8.2.5)
     chartkick (2.2.3)
+    climate_control (0.2.0)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -93,6 +94,7 @@ GEM
       activemodel
     erubis (2.7.0)
     execjs (2.6.0)
+    fakefs (0.11.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     geocoder (1.3.4)
@@ -324,11 +326,13 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   byebug
   chartkick
+  climate_control (~> 0.2)
   coffee-rails (~> 4.1.0)
   devise (~> 3.5)
   devise-bootstrap-views (~> 0.0.7)
   devise_security_extension (~> 0.10)
   email_validator (~> 1.6)
+  fakefs (~> 0.11)
   geocoder
   google-api-client (~> 0.9)
   gratefulgarment-ui!

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,9 @@ Bundler.require(*Rails.groups)
 
 module StockAid
   class Application < Rails::Application
+    require "down_for_maintenance"
+    config.middleware.unshift DownForMaintenance
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/down_for_maintenance.rb
+++ b/lib/down_for_maintenance.rb
@@ -1,0 +1,186 @@
+# This is a Rack middleware for presenting a down for maintenance page. It can
+# be enabled via setting the STOCKAID_DOWN_FOR_MAINTENANCE environment variable
+# to a value, or by touching the tmp/down_for_maintenance.txt file.
+#
+# If you want to customize the message, you can use environment variables or the
+# above file. For environment variables, you can use:
+# * STOCKAID_DOWN_FOR_MAINTENANCE_TITLE
+# * STOCKAID_DOWN_FOR_MAINTENANCE_MESSAGE
+# * STOCKAID_DOWN_FOR_MAINTENANCE_SUBMESSAGE
+#
+# You could also use the context of the file. If only 1 line is provided, it
+# will override the message. If 2 lines are provided, the first will be the
+# title, and the second will be the message. If 3 lines are provided, the first
+# will be the title, the second is the message, and the third will be the
+# submessage.
+#
+# For customized messages, the file will first be considered, then the
+# environment.
+class DownForMaintenance
+  FILE_PATH = "tmp/down_for_maintenance.txt".freeze
+  DOWN_FOR_MAINTENANCE_STATUS = 503
+  DEFAULT_TITLE = "Down for Maintenance".freeze
+  DEFAULT_MESSAGE = "The site is currently down for maintenance and will be back up as soon as possible".freeze
+  DEFAULT_SUBMESSAGE = "".freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if enabled?
+      read_file
+      [DOWN_FOR_MAINTENANCE_STATUS, headers, [html]]
+    else
+      @app.call(env)
+    end
+  end
+
+  def down_for_maintenance_file
+    @down_for_maintenance_file ||= Rails.root.join(FILE_PATH)
+  end
+
+  def title
+    if @file_contents.size >= 2
+      @file_contents[0]
+    elsif ENV["STOCKAID_DOWN_FOR_MAINTENANCE_TITLE"].present?
+      ENV["STOCKAID_DOWN_FOR_MAINTENANCE_TITLE"]
+    else
+      DEFAULT_TITLE
+    end
+  end
+
+  def message
+    if @file_contents.size == 1
+      @file_contents[0]
+    elsif @file_contents.size >= 2
+      @file_contents[1]
+    elsif ENV["STOCKAID_DOWN_FOR_MAINTENANCE_MESSAGE"].present?
+      ENV["STOCKAID_DOWN_FOR_MAINTENANCE_MESSAGE"]
+    else
+      DEFAULT_MESSAGE
+    end
+  end
+
+  def submessage
+    if @file_contents.size >= 3
+      @file_contents[2]
+    elsif ENV["STOCKAID_DOWN_FOR_MAINTENANCE_SUBMESSAGE"].present?
+      ENV["STOCKAID_DOWN_FOR_MAINTENANCE_SUBMESSAGE"]
+    else
+      DEFAULT_SUBMESSAGE
+    end
+  end
+
+  private
+
+  def read_file
+    @file_contents =
+      if file_enabled?
+        down_for_maintenance_file.readlines.map(&:strip)
+      else
+        []
+      end
+  end
+
+  def enabled?
+    env_enabled? || file_enabled?
+  end
+
+  def env_enabled?
+    ENV["STOCKAID_DOWN_FOR_MAINTENANCE"].present?
+  end
+
+  def file_enabled?
+    down_for_maintenance_file.exist?
+  end
+
+  def headers
+    {
+      "Cache-Control" => "max-age=0, private, must-revalidate",
+      "Content-Type" => "text/html"
+    }
+  end
+
+  def html # rubocop:disable Metrics/MethodLength
+    title_html = ERB::Util.html_escape(title)
+    message_html = %(<p class="message">#{ERB::Util.html_escape(message)}</p>)
+    submessage_html = submessage
+
+    if submessage_html.present?
+      submessage_html = %(<p class="submessage">#{ERB::Util.html_escape(submessage_html)}</p>)
+    else
+      submessage_html = message_html
+      message_html = ""
+    end
+
+    %(<!DOCTYPE html>
+<html>
+  <head>
+    <title>#{title_html}</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style>
+      body {
+        background-color: #EFEFEF;
+        color: #2E2F30;
+        text-align: center;
+        font-family: arial, sans-serif;
+        margin: 0;
+      }
+
+      div.dialog {
+        width: 95%;
+        max-width: 33em;
+        margin: 4em auto 0;
+      }
+
+      div.dialog > div {
+        border: 1px solid #CCC;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #BBB;
+        border-top: #B00100 solid 4px;
+        border-top-left-radius: 9px;
+        border-top-right-radius: 9px;
+        background-color: white;
+        padding: 7px 12% 0;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+
+      h1 {
+        font-size: 100%;
+        color: #730E15;
+        line-height: 1.5em;
+      }
+
+      div.dialog > p {
+        margin: 0 0 1em;
+        padding: 1em;
+        background-color: #F7F7F7;
+        border: 1px solid #CCC;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #999;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-top-color: #DADADA;
+        color: #666;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="dialog">
+      <div>
+        <h1>#{title_html}</h1>
+        #{message_html}
+      </div>
+
+      #{submessage_html}
+    </div>
+  </body>
+</html>
+)
+  end
+end

--- a/spec/lib/down_for_maintenance_spec.rb
+++ b/spec/lib/down_for_maintenance_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+describe DownForMaintenance do
+  let(:fake_app) do
+    lambda do |_env|
+      @called = true
+      :lambda_result
+    end
+  end
+
+  let(:middleware) { DownForMaintenance.new(fake_app) }
+
+  context "not enabled" do
+    it "invokes the app" do
+      result = middleware.call({})
+      expect(result).to eq(:lambda_result)
+      expect(@called).to be_truthy
+    end
+  end
+
+  context "enabled via environment" do
+    it "can just enable the maintenance" do
+      with_env STOCKAID_DOWN_FOR_MAINTENANCE: "true" do
+        result = middleware.call({})
+        expect(@called).to be_falsey
+        expect(result[2].first).to match(%r{<title>#{DownForMaintenance::DEFAULT_TITLE}</title>})
+        expect(result[2].first).to match(%r{<h1>#{DownForMaintenance::DEFAULT_TITLE}</h1>})
+        expect(result[2].first).to match(%r{<p class="message">#{DownForMaintenance::DEFAULT_MESSAGE}</p>})
+        expect(result[2].first).to_not match(/<p class="submessage">/)
+      end
+    end
+
+    it "can override the page details" do
+      with_env STOCKAID_DOWN_FOR_MAINTENANCE: "true",
+               STOCKAID_DOWN_FOR_MAINTENANCE_TITLE: "Custom Title",
+               STOCKAID_DOWN_FOR_MAINTENANCE_MESSAGE: "Custom Message",
+               STOCKAID_DOWN_FOR_MAINTENANCE_SUBMESSAGE: "Custom Submessage" do
+        result = middleware.call({})
+        expect(@called).to be_falsey
+        expect(result[2].first).to match(%r{<title>Custom Title</title>})
+        expect(result[2].first).to match(%r{<h1>Custom Title</h1>})
+        expect(result[2].first).to match(%r{<p class="message">Custom Message</p>})
+        expect(result[2].first).to match(%r{<p class="submessage">Custom Submessage</p>})
+      end
+    end
+
+    it "sanitizes the overridden details" do
+      with_env STOCKAID_DOWN_FOR_MAINTENANCE: "true",
+               STOCKAID_DOWN_FOR_MAINTENANCE_TITLE: "Custom <Title>",
+               STOCKAID_DOWN_FOR_MAINTENANCE_MESSAGE: "Custom <Message>",
+               STOCKAID_DOWN_FOR_MAINTENANCE_SUBMESSAGE: "Custom <Submessage>" do
+        result = middleware.call({})
+        expect(@called).to be_falsey
+        expect(result[2].first).to match(%r{<title>Custom &lt;Title&gt;</title>})
+        expect(result[2].first).to match(%r{<h1>Custom &lt;Title&gt;</h1>})
+        expect(result[2].first).to match(%r{<p class="message">Custom &lt;Message&gt;</p>})
+        expect(result[2].first).to match(%r{<p class="submessage">Custom &lt;Submessage&gt;</p>})
+      end
+    end
+  end
+
+  context "enabled via files" do
+    include FakeFS::SpecHelpers
+    let(:maintenance_file) { middleware.down_for_maintenance_file }
+    before { FileUtils.mkdir_p maintenance_file.dirname }
+
+    it "can just enable the maintenance" do
+      File.write(maintenance_file, "")
+      result = middleware.call({})
+      expect(@called).to be_falsey
+      expect(result[2].first).to match(%r{<title>#{DownForMaintenance::DEFAULT_TITLE}</title>})
+      expect(result[2].first).to match(%r{<h1>#{DownForMaintenance::DEFAULT_TITLE}</h1>})
+      expect(result[2].first).to match(%r{<p class="message">#{DownForMaintenance::DEFAULT_MESSAGE}</p>})
+      expect(result[2].first).to_not match(/<p class="submessage">/)
+    end
+
+    it "can override just the message" do
+      File.write(maintenance_file, "Custom Message\n")
+      result = middleware.call({})
+      expect(@called).to be_falsey
+      expect(result[2].first).to match(%r{<title>#{DownForMaintenance::DEFAULT_TITLE}</title>})
+      expect(result[2].first).to match(%r{<h1>#{DownForMaintenance::DEFAULT_TITLE}</h1>})
+      expect(result[2].first).to match(%r{<p class="message">Custom Message</p>})
+      expect(result[2].first).to_not match(/<p class="submessage">/)
+    end
+
+    it "can override just the message and title" do
+      File.write(maintenance_file, "Custom Title\nCustom Message\n")
+      result = middleware.call({})
+      expect(@called).to be_falsey
+      expect(result[2].first).to match(%r{<title>Custom Title</title>})
+      expect(result[2].first).to match(%r{<h1>Custom Title</h1>})
+      expect(result[2].first).to match(%r{<p class="message">Custom Message</p>})
+      expect(result[2].first).to_not match(/<p class="submessage">/)
+    end
+
+    it "can override all the page details" do
+      File.write(maintenance_file, "Custom Title\nCustom Message\nCustom Submessage\n")
+      result = middleware.call({})
+      expect(@called).to be_falsey
+      expect(result[2].first).to match(%r{<title>Custom Title</title>})
+      expect(result[2].first).to match(%r{<h1>Custom Title</h1>})
+      expect(result[2].first).to match(%r{<p class="message">Custom Message</p>})
+      expect(result[2].first).to match(%r{<p class="submessage">Custom Submessage</p>})
+    end
+
+    it "sanitizes the overridden details" do
+      File.write(maintenance_file, "Custom <Title>\nCustom <Message>\nCustom <Submessage>\n")
+      result = middleware.call({})
+      expect(@called).to be_falsey
+      expect(result[2].first).to match(%r{<title>Custom &lt;Title&gt;</title>})
+      expect(result[2].first).to match(%r{<h1>Custom &lt;Title&gt;</h1>})
+      expect(result[2].first).to match(%r{<p class="message">Custom &lt;Message&gt;</p>})
+      expect(result[2].first).to match(%r{<p class="submessage">Custom &lt;Submessage&gt;</p>})
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,9 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "spec_helper"
 require "rspec/rails"
+require "fakefs/spec_helpers"
 # Add additional requires below this line. Rails is not loaded until this point!
+require_relative "support/climate_helper"
 require_relative "support/controllers_helper"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -70,5 +72,6 @@ RSpec.configure do |config|
     ActionMailer::Base.deliveries.clear
   end
 
+  config.include ClimateHelper
   config.include ControllersHelper
 end

--- a/spec/support/climate_helper.rb
+++ b/spec/support/climate_helper.rb
@@ -1,0 +1,5 @@
+module ClimateHelper
+  def with_env(env, &block)
+    ClimateControl.modify(env, &block)
+  end
+end


### PR DESCRIPTION
The page will be controllable via environment variables:
* `STOCKAID_DOWN_FOR_MAINTENANCE`
* `STOCKAID_DOWN_FOR_MAINTENANCE_TITLE`
* `STOCKAID_DOWN_FOR_MAINTENANCE_MESSAGE`
* `STOCKAID_DOWN_FOR_MAINTENANCE_SUBMESSAGE`

Or the file: `tmp/down_for_maintenance.txt`

See `lib/down_for_maintenance.rb` for details