### PR TITLE
Update 'item' model to change 'edit item stock' verbiage

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,7 +19,7 @@ class Item < ActiveRecord::Base
   attr_accessor :edit_amount, :edit_method, :edit_reason, :edit_source
   attr_writer :requested_quantity
 
-  enum edit_reasons: [:donation, :purchase, :correction, :order_adjustment]
+  enum edit_reasons: [:donation, :purchase, :adjustment, :order_adjustment]
   enum edit_methods: [:add, :subtract, :new_total]
 
   def self.find_any(id)


### PR DESCRIPTION
Changes "Correction" to "Adjustment" on "Edit Item Stock" page seen here:

http://localhost:3000/inventory/73/edit_stock

![screen shot 2017-05-26 at 6 32 51 pm](https://cloud.githubusercontent.com/assets/8742778/26516831/c55b5afe-4241-11e7-8174-3298c678e5e7.png)
