### PR TITLE
Add date filter option in Total inventory value (Issue 489)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem "rubocop", "~> 0.36"
   gem "awesome_print"
   gem "pry-byebug"
+  gem "dotenv"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     diff-lcs (1.2.5)
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.1.1)
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -334,6 +335,7 @@ DEPENDENCIES
   devise (~> 3.5)
   devise-bootstrap-views (~> 0.0.7)
   devise_security_extension (~> 0.10)
+  dotenv
   email_validator (~> 1.6)
   fakefs (~> 0.11)
   geocoder

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,7 +13,7 @@ class ReportsController < ApplicationController
   end
 
   def total_inventory_value
-    params[:date] ||= Time.now.strftime("%m/%d/%Y")
+    params[:date] ||= Time.zone.now.strftime("%m/%d/%Y")
     @report = Reports::TotalInventoryValue.new(params, session)
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,6 +13,7 @@ class ReportsController < ApplicationController
   end
 
   def total_inventory_value
+    params[:date] ||= Time.now.strftime("%m/%d/%Y")
     @report = Reports::TotalInventoryValue.new(params, session)
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,7 +16,7 @@ class Category < ActiveRecord::Base
     if at.blank?
       items.sum("current_quantity * value")
     else
-      items.includes(:versions).inject(0) do |sum, item| 
+      items.includes(:versions).inject(0) do |sum, item|
         sum + item.total_value(at: at)
       end
     end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,8 +12,14 @@ class Category < ActiveRecord::Base
     }
   end
 
-  def value
-    items.sum("current_quantity * value")
+  def value(at: nil)
+    if at.blank?
+      items.sum("current_quantity * value")
+    else
+      items.includes(:versions).inject(0) do |sum, item| 
+        sum + item.total_value(at: at)
+      end
+    end
   end
 
   def self.to_json

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -77,8 +77,22 @@ class Item < ActiveRecord::Base
     deleted_at != nil
   end
 
-  def total_value
-    current_quantity * value
+  def version_at(at)
+    return self if at >= self.updated_at
+    return versions.sort_by { |v| v.created_at }.reverse
+      .find { |v| v.created_at <= at }.try(:reify) 
+  end
+
+  def total_value(at: nil)
+    if at.blank?
+      current_quantity * value
+    else
+      prev_version = self.version_at(at)
+
+      if prev_version.present?
+        prev_version.current_quantity * prev_version.value
+      end
+    end
   end
 
   def requested_quantity

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -80,11 +80,12 @@ class Item < ActiveRecord::Base
   def past_version_value(time)
     past_version = versions.sort_by(&:created_at).reverse
                            .find { |v| v.created_at <= time }.try(:reify)
+    return nil if past_version.blank?
     past_version.current_quantity * past_version.value
   end
 
   def total_value(at: nil)
-    return current_quantity * value if at.blank?
+    return current_quantity * value if at.blank? || at >= updated_at
     past_version_value(at)
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -78,16 +78,16 @@ class Item < ActiveRecord::Base
   end
 
   def version_at(at)
-    return self if at >= self.updated_at
-    return versions.sort_by { |v| v.created_at }.reverse
-      .find { |v| v.created_at <= at }.try(:reify) 
+    return self if at >= updated_at
+    versions.sort_by(&:created_at).reverse
+            .find { |v| v.created_at <= at }.try(:reify)
   end
 
   def total_value(at: nil)
     if at.blank?
       current_quantity * value
     else
-      prev_version = self.version_at(at)
+      prev_version = version_at(at)
 
       if prev_version.present?
         prev_version.current_quantity * prev_version.value

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -77,22 +77,15 @@ class Item < ActiveRecord::Base
     deleted_at != nil
   end
 
-  def version_at(at)
-    return self if at >= updated_at
-    versions.sort_by(&:created_at).reverse
-            .find { |v| v.created_at <= at }.try(:reify)
+  def past_version_value(time)
+    past_version = versions.sort_by(&:created_at).reverse
+                           .find { |v| v.created_at <= time }.try(:reify)
+    past_version.current_quantity * past_version.value
   end
 
   def total_value(at: nil)
-    if at.blank?
-      current_quantity * value
-    else
-      prev_version = version_at(at)
-
-      if prev_version.present?
-        prev_version.current_quantity * prev_version.value
-      end
-    end
+    return current_quantity * value if at.blank?
+    past_version_value(at)
   end
 
   def requested_quantity

--- a/app/models/reports/total_inventory_value.rb
+++ b/app/models/reports/total_inventory_value.rb
@@ -7,7 +7,7 @@ module Reports
         Reports::TotalInventoryValue::AllCategories.new(params)
       end
     end
-    
+
     module Common
       def date
         return if @params[:date].blank?

--- a/app/models/reports/total_inventory_value.rb
+++ b/app/models/reports/total_inventory_value.rb
@@ -4,7 +4,7 @@ module Reports
       if params[:category_id].present?
         Reports::TotalInventoryValue::SingleCategory.new(params)
       else
-        Reports::TotalInventoryValue::AllCategories.new
+        Reports::TotalInventoryValue::AllCategories.new(params)
       end
     end
 
@@ -13,35 +13,51 @@ module Reports
 
       def initialize(params)
         @category = Category.find(params[:category_id])
+        @params = params
       end
 
       def each
         category.items.order(:description).each do |item|
-          yield item.description, item.total_value
+          yield item.description, item.total_value(at: date)
         end
       end
 
       def total_value
         category.value
       end
+
+      def date
+        if @params[:date].present?      
+          Date.strptime(@params[:date], "%m/%d/%Y").end_of_day
+        end
+      end
+
     end
 
     class AllCategories
       attr_reader :categories
 
-      def initialize
+      def initialize(params)
         @categories = Category.all
+        @params = params
       end
 
       def each
         categories.each do |category|
-          yield category.description, category.value
+          yield category.description, category.value(at: date)
         end
       end
 
       def total_value
         categories.to_a.sum(&:value)
       end
+
+      def date
+        if @params[:date].present?      
+          Date.strptime(@params[:date], "%m/%d/%Y").end_of_day
+        end
+      end
+
     end
   end
 end

--- a/app/models/reports/total_inventory_value.rb
+++ b/app/models/reports/total_inventory_value.rb
@@ -27,11 +27,9 @@ module Reports
       end
 
       def date
-        if @params[:date].present?
-          Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
-        end
+        return if @params[:date].blank?
+        Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
       end
-
     end
 
     class AllCategories
@@ -53,11 +51,9 @@ module Reports
       end
 
       def date
-        if @params[:date].present?      
-          Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
-        end
+        return if @params[:date].blank?
+        Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
       end
-
     end
   end
 end

--- a/app/models/reports/total_inventory_value.rb
+++ b/app/models/reports/total_inventory_value.rb
@@ -27,8 +27,8 @@ module Reports
       end
 
       def date
-        if @params[:date].present?      
-          Date.strptime(@params[:date], "%m/%d/%Y").end_of_day
+        if @params[:date].present?
+          Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
         end
       end
 
@@ -54,7 +54,7 @@ module Reports
 
       def date
         if @params[:date].present?      
-          Date.strptime(@params[:date], "%m/%d/%Y").end_of_day
+          Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
         end
       end
 

--- a/app/models/reports/total_inventory_value.rb
+++ b/app/models/reports/total_inventory_value.rb
@@ -7,8 +7,16 @@ module Reports
         Reports::TotalInventoryValue::AllCategories.new(params)
       end
     end
+    
+    module Common
+      def date
+        return if @params[:date].blank?
+        Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
+      end
+    end
 
     class SingleCategory
+      include Common
       attr_reader :category
 
       def initialize(params)
@@ -25,14 +33,10 @@ module Reports
       def total_value
         category.value
       end
-
-      def date
-        return if @params[:date].blank?
-        Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
-      end
     end
 
     class AllCategories
+      include Common
       attr_reader :categories
 
       def initialize(params)
@@ -48,11 +52,6 @@ module Reports
 
       def total_value
         categories.to_a.sum(&:value)
-      end
-
-      def date
-        return if @params[:date].blank?
-        Time.strptime(@params[:date], "%m/%d/%Y").end_of_day
       end
     end
   end

--- a/app/views/reports/_total_inventory_value_filters.html.erb
+++ b/app/views/reports/_total_inventory_value_filters.html.erb
@@ -1,0 +1,16 @@
+<div class="row">
+  <div class="col-xs-12">
+    <form class="form-inline pull-right">
+      <%= form_tag(total_inventory_value_reports_path, method: "get") do %>
+        <%= label_tag(:date, "Date", class: "control-label") %>
+        <%= text_field_tag(:date, params[:date], {:'data-provide' => 'datepicker'}) %>
+        <%= hidden_field_tag :category_id, request.params[:category_id]  %>
+        <%= submit_tag("Filter", class: "btn btn-default") %>
+      <% end %>
+    </form>
+  </div>
+</div>
+
+<br />
+
+

--- a/app/views/reports/_total_inventory_value_table.html.erb
+++ b/app/views/reports/_total_inventory_value_table.html.erb
@@ -1,0 +1,24 @@
+<table class="table table-striped table-responsive data-table">
+  <thead>
+    <tr>
+      <th class="text-center">Description</th>
+      <th class="text-center">Value</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% report.each do |description, value| %>
+      <tr>
+        <td class="text-center"><%= description %></td>
+        <td class="text-center"><%= number_to_currency value, precision: 2 %></td>
+      </tr>
+    <% end %>
+  </tbody>
+
+  <tfoot>
+    <tr>
+      <th class="text-center"></th>
+      <th class="text-center"><%= number_to_currency report.total_value, precision: 2 %></th>
+    </tr>
+  </tfoot>
+</table>

--- a/app/views/reports/total_inventory_value.html.erb
+++ b/app/views/reports/total_inventory_value.html.erb
@@ -6,12 +6,20 @@
   <ul class="nav nav-pills nav-stacked">
     <%= tab("All Categories", total_inventory_value_reports_path, params[:category_id].blank?) %>
     <% Category.all.each do |category| %>
-      <%= tab(category.description, total_inventory_value_reports_path(category_id: category.id), params[:category_id].present? && category.id == params[:category_id].to_i) %>
+      <%= tab(category.description, total_inventory_value_reports_path(category_id: category.id, date: params[:date]), params[:category_id].present? && category.id == params[:category_id].to_i) %>
     <% end %>
   </ul>
 <% end %>
 
 <% content_for :content do %>
+
+  <%= form_tag(total_inventory_value_reports_path, method: "get") do %>
+    <%= label_tag(:date, "Date") %>
+    <%= text_field_tag(:date, params[:date], {:'data-provide' => 'datepicker'}) %>
+    <%= hidden_field_tag :category_id, request.params[:category_id]  %>
+    <%= submit_tag("Search") %>
+  <% end %>
+
   <div class="tab-content">
     <table class="table table-hover table-striped">
       <thead>

--- a/app/views/reports/total_inventory_value.html.erb
+++ b/app/views/reports/total_inventory_value.html.erb
@@ -3,7 +3,7 @@
 <% content_for :content_size, "col-sm-9 col-md-10" %>
 
 <% content_for :sidebar do %>
-  <ul class="nav nav-pills nav-stacked">
+  <ul class="nav nav-pills nav-stacked" role="tablist">
     <%= tab("All Categories", total_inventory_value_reports_path, params[:category_id].blank?) %>
     <% Category.all.each do |category| %>
       <%= tab(category.description, total_inventory_value_reports_path(category_id: category.id, date: params[:date]), params[:category_id].present? && category.id == params[:category_id].to_i) %>
@@ -12,38 +12,13 @@
 <% end %>
 
 <% content_for :content do %>
-
-  <%= form_tag(total_inventory_value_reports_path, method: "get") do %>
-    <%= label_tag(:date, "Date") %>
-    <%= text_field_tag(:date, params[:date], {:'data-provide' => 'datepicker'}) %>
-    <%= hidden_field_tag :category_id, request.params[:category_id]  %>
-    <%= submit_tag("Search") %>
-  <% end %>
-
-  <div class="tab-content">
-    <table class="table table-hover table-striped">
-      <thead>
-        <tr>
-          <th class="col-xs-4">Description</th>
-          <th class="text-center">value</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @report.each do |description, value| %>
-          <tr>
-            <td class="col-xs-4"><%= description %></td>
-            <td class="text-center"><%= number_to_currency(value, precision: 2) %></td>
-          </tr>
-        <% end %>
-      </tbody>
-
-      <tfoot>
-        <tr>
-          <th class="col-xs-4">Total</th>
-          <th class="text-center"><%= number_to_currency(@report.total_value, precision: 2) %></th>
-        </tr>
-      </tfoot>
-    </table>
+  
+  <div class="hidden-print">
+    <div class="tab-content">
+      <%= render partial: "total_inventory_value_filters" %>
+      <%= render partial: "reports/total_inventory_value_table", locals: { report: @report } %>
+    </div>
   </div>
+  
 <% end %>
+

--- a/lib/environment_setup.rb
+++ b/lib/environment_setup.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 # rubocop:disable Rails/Output
+
+require 'dotenv'
+Dotenv.load('.ruby-env')
+
 class EnvironmentSetup
   # Increment this version if you change the setup such that everyone should re-run this
   VERSION = 3

--- a/lib/environment_setup.rb
+++ b/lib/environment_setup.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 # rubocop:disable Rails/Output
 
-require 'dotenv'
-Dotenv.load('.ruby-env')
+require "dotenv"
+Dotenv.load(".ruby-env")
 
 class EnvironmentSetup
   # Increment this version if you change the setup such that everyone should re-run this


### PR DESCRIPTION
Related to Issue:
https://github.com/on-site/StockAid/issues/489

This PR adds the ability to return the Total Inventory Value report for a given date provided. I took a few liberties in making this.

- Update associated methods in Category & Item to accept an optional `date` parameter
- Added a date search form
- Added the `dotenv` gem to avoid having to use rvm to load ENV variables
<img width="1006" alt="screen shot 2017-10-17 at 11 23 31 pm" src="https://user-images.githubusercontent.com/11335191/31699764-d2b0fa5c-b392-11e7-8995-c75bbf4a5c7a.png">

Please let me know if there is any improvements or changes I need to make. Thanks! 
P.S: Sorry for the late PR (I was expecting it to be done last week)
