### PR TITLE
Fix unhandled nils in Total Value report

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,7 +17,12 @@ class Category < ActiveRecord::Base
       items.sum("current_quantity * value")
     else
       items.includes(:versions).inject(0) do |sum, item|
-        sum + (item.total_value(at: at) || 0)
+        total = item.total_value(at: at)
+        if total.present?
+          sum + total
+        else
+          sum
+        end
       end
     end
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,7 +17,7 @@ class Category < ActiveRecord::Base
       items.sum("current_quantity * value")
     else
       items.includes(:versions).inject(0) do |sum, item|
-        sum + item.total_value(at: at)
+        sum + (item.total_value(at: at) || 0)
       end
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -77,16 +77,20 @@ class Item < ActiveRecord::Base
     deleted_at != nil
   end
 
-  def past_version_value(time)
-    past_version = versions.sort_by(&:created_at).reverse
-                           .find { |v| v.created_at <= time }.try(:reify)
-    return nil if past_version.blank?
+  def past_total_value(time)
+    past_version = version_at(time)
+    return nil if past_version.blank? || past_version.value.nil?
     past_version.current_quantity * past_version.value
   end
 
   def total_value(at: nil)
-    return current_quantity * value if at.blank? || at >= updated_at
-    past_version_value(at)
+    return current_total_value if at.blank? || at >= updated_at
+    past_total_value(at)
+  end
+
+  def current_total_value
+    return if value.nil?
+    current_quantity * value
   end
 
   def requested_quantity


### PR DESCRIPTION
This PR fixes the bug described in: https://github.com/on-site/StockAid/issues/546

In summary this issue was caused by performing operations on unhandled nils. 

- The paper trail `.reify` method returns nil if the version is a `create`. Hence there would be an issue if the only version is the create. I replaced the complex logic in favor of using  `.version_at(time)` provided by paper trail.
- Renamed `past_version_value` to `past_total_value` as the former method name is misleading. The return value should not be confused with the column `value`
- Item records can have a `nil` total_value, these shouldn't be counted in the total `.value` in Category

Thanks. Let me know if there is any suggestions or questions.